### PR TITLE
Update spring-integration-twitter to 3.0.0.RELEASE

### DIFF
--- a/complete/pom.xml
+++ b/complete/pom.xml
@@ -22,7 +22,7 @@
         <dependency>
             <groupId>org.springframework.integration</groupId>
             <artifactId>spring-integration-twitter</artifactId>
-            <version>2.2.4.RELEASE</version>
+            <version>3.0.0.RELEASE</version>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
Previous value (2.2.4.RELEASE) causes a runtime exception:
- ClassNotFoundException: org.springframework.integration.store.MetadataStore
