### PR TITLE
Update spring-integration-twitter to 3.0.0.RELEASE

### DIFF
--- a/complete/build.gradle
+++ b/complete/build.gradle
@@ -25,7 +25,7 @@ repositories {
 
 dependencies {
     compile("org.springframework.boot:spring-boot-starter-integration:1.0.0.RC1")
-    compile("org.springframework.integration:spring-integration-twitter:2.2.4.RELEASE")
+    compile("org.springframework.integration:spring-integration-twitter:3.0.0.RELEASE")
     testCompile("junit:junit:4.11")
 }
 


### PR DESCRIPTION
Previous value (2.2.4.RELEASE) causes a runtime exception:
- ClassNotFoundException: org.springframework.integration.store.MetadataStore
