### PR TITLE
GH-11: Add `System.in` hook to build.gradle

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,7 @@ dependency-reduced-pom.xml
 .gradle
 
 README.html
+/initial/.idea
+/complete/.idea
+/initial/*.iml
+/complete/*.iml

--- a/complete/build.gradle
+++ b/complete/build.gradle
@@ -26,8 +26,12 @@ targetCompatibility = 1.8
 
 dependencies {
     compile("org.springframework.boot:spring-boot-starter-integration")
-    compile("org.springframework.integration:spring-integration-feed:4.0.4.RELEASE")
+    compile("org.springframework.integration:spring-integration-feed")
     testCompile("junit:junit")
+}
+
+tasks.withType(JavaExec) {
+    standardInput = System.in
 }
 
 task wrapper(type: Wrapper) {

--- a/complete/pom.xml
+++ b/complete/pom.xml
@@ -26,7 +26,6 @@
         <dependency>
             <groupId>org.springframework.integration</groupId>
             <artifactId>spring-integration-feed</artifactId>
-            <version>4.0.4.RELEASE</version>
         </dependency>
     </dependencies>
 

--- a/initial/build.gradle
+++ b/initial/build.gradle
@@ -26,8 +26,12 @@ targetCompatibility = 1.8
 
 dependencies {
     compile("org.springframework.boot:spring-boot-starter-integration")
-    compile("org.springframework.integration:spring-integration-feed:4.0.4.RELEASE")
+    compile("org.springframework.integration:spring-integration-feed")
     testCompile("junit:junit")
+}
+
+tasks.withType(JavaExec) {
+    standardInput = System.in
 }
 
 task wrapper(type: Wrapper) {

--- a/initial/pom.xml
+++ b/initial/pom.xml
@@ -26,7 +26,6 @@
         <dependency>
             <groupId>org.springframework.integration</groupId>
             <artifactId>spring-integration-feed</artifactId>
-            <version>4.0.4.RELEASE</version>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
Fixes GH-11 (https://github.com/spring-guides/gs-integration/issues/11)

* Remove redundant SI version for dependency. Relying only on the `spring-boot-starter-integration` resolution