### PR TITLE
Add `spring-integration-file` dependency

### DIFF
--- a/complete/build.gradle
+++ b/complete/build.gradle
@@ -27,6 +27,7 @@ targetCompatibility = 1.8
 dependencies {
     compile("org.springframework.boot:spring-boot-starter-integration")
     compile("org.springframework.integration:spring-integration-feed")
+    compile("org.springframework.integration:spring-integration-file")
     testCompile("junit:junit")
 }
 

--- a/complete/pom.xml
+++ b/complete/pom.xml
@@ -27,6 +27,10 @@
             <groupId>org.springframework.integration</groupId>
             <artifactId>spring-integration-feed</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.springframework.integration</groupId>
+            <artifactId>spring-integration-file</artifactId>
+        </dependency>
     </dependencies>
 
 

--- a/initial/build.gradle
+++ b/initial/build.gradle
@@ -27,6 +27,7 @@ targetCompatibility = 1.8
 dependencies {
     compile("org.springframework.boot:spring-boot-starter-integration")
     compile("org.springframework.integration:spring-integration-feed")
+    compile("org.springframework.integration:spring-integration-file")
     testCompile("junit:junit")
 }
 

--- a/initial/pom.xml
+++ b/initial/pom.xml
@@ -27,6 +27,10 @@
             <groupId>org.springframework.integration</groupId>
             <artifactId>spring-integration-feed</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.springframework.integration</groupId>
+            <artifactId>spring-integration-file</artifactId>
+        </dependency>
     </dependencies>
 
 


### PR DESCRIPTION
Fixes https://github.com/spring-guides/gs-integration/issues/14

According to the spring-projects/spring-boot@c068285 there is no `spring-integration-file` jar in the classpath since Spring Boot 1.4.

To make application working explicitly add `spring-integration-file` dependency