### PR TITLE
URL Cleanup

### DIFF
--- a/LICENSE.writing.txt
+++ b/LICENSE.writing.txt
@@ -1,1 +1,1 @@
-Except where otherwise noted, this work is licensed under http://creativecommons.org/licenses/by-nd/3.0/
+Except where otherwise noted, this work is licensed under https://creativecommons.org/licenses/by-nd/3.0/

--- a/README.adoc
+++ b/README.adoc
@@ -1,10 +1,10 @@
 :spring_version: current
 :spring_boot_version: 1.5.1.RELEASE
-:SpringSocial: http://projects.spring.io/spring-social/
-:Component: http://docs.spring.io/spring/docs/{spring_version}/javadoc-api/org/springframework/stereotype/Component.html
-:EnableAutoConfiguration: http://docs.spring.io/spring-boot/docs/{spring_boot_version}/api/org/springframework/boot/autoconfigure/EnableAutoConfiguration.html
-:DispatcherServlet: http://docs.spring.io/spring/docs/{spring_version}/javadoc-api/org/springframework/web/servlet/DispatcherServlet.html
-:SpringApplication: http://docs.spring.io/spring-boot/docs/{spring_boot_version}/api/org/springframework/boot/SpringApplication.html
+:SpringSocial: https://projects.spring.io/spring-social/
+:Component: https://docs.spring.io/spring/docs/{spring_version}/javadoc-api/org/springframework/stereotype/Component.html
+:EnableAutoConfiguration: https://docs.spring.io/spring-boot/docs/{spring_boot_version}/api/org/springframework/boot/autoconfigure/EnableAutoConfiguration.html
+:DispatcherServlet: https://docs.spring.io/spring/docs/{spring_version}/javadoc-api/org/springframework/web/servlet/DispatcherServlet.html
+:SpringApplication: https://docs.spring.io/spring-boot/docs/{spring_boot_version}/api/org/springframework/boot/SpringApplication.html
 :gs-register-twitter-app: link:/guides/gs/register-twitter-app
 :toc:
 :icons: font

--- a/complete/src/test/java/hello/FlowTests.java
+++ b/complete/src/test/java/hello/FlowTests.java
@@ -34,7 +34,7 @@ public class FlowTests {
 		assertThat(this.newsAdapter.isRunning()).isFalse();
 		SyndEntryImpl syndEntry = new SyndEntryImpl();
 		syndEntry.setTitle("Test Title");
-		syndEntry.setLink("http://foo/bar");
+		syndEntry.setLink("https://foo/bar");
 		File out = new File("/tmp/si/Test");
 		out.delete();
 		assertThat(out.exists()).isFalse();
@@ -42,7 +42,7 @@ public class FlowTests {
 		assertThat(out.exists()).isTrue();
 		BufferedReader br = new BufferedReader(new FileReader(out));
 		String line = br.readLine();
-		assertThat(line).isEqualTo("Test Title @ http://foo/bar");
+		assertThat(line).isEqualTo("Test Title @ https://foo/bar");
 		br.close();
 		out.delete();
 	}


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed But Review Recommended
These URLs were fixed, but the https status was not OK. However, the https status was the same as the http request or http redirected to an https URL, so they were migrated. Your review is recommended.

* [ ] http://foo/bar (UnknownHostException) with 2 occurrences migrated to:  
  https://foo/bar ([https](https://foo/bar) result UnknownHostException).

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* [ ] http://creativecommons.org/licenses/by-nd/3.0/ with 1 occurrences migrated to:  
  https://creativecommons.org/licenses/by-nd/3.0/ ([https](https://creativecommons.org/licenses/by-nd/3.0/) result 200).
* [ ] http://docs.spring.io/spring-boot/docs/ with 2 occurrences migrated to:  
  https://docs.spring.io/spring-boot/docs/ ([https](https://docs.spring.io/spring-boot/docs/) result 200).
* [ ] http://docs.spring.io/spring/docs/ with 2 occurrences migrated to:  
  https://docs.spring.io/spring/docs/ ([https](https://docs.spring.io/spring/docs/) result 200).
* [ ] http://projects.spring.io/spring-social/ with 1 occurrences migrated to:  
  https://projects.spring.io/spring-social/ ([https](https://projects.spring.io/spring-social/) result 200).