### PR TITLE
Add spring-integration-feed & spring-integration-file dependencies

### DIFF
--- a/initial/build.gradle
+++ b/initial/build.gradle
@@ -14,6 +14,8 @@ repositories {
 
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-integration'
+	implementation 'org.springframework.integration:spring-integration-feed'
+	implementation 'org.springframework.integration:spring-integration-file'
 	testImplementation('org.springframework.boot:spring-boot-starter-test')
 	testImplementation 'org.springframework.integration:spring-integration-test'
 }

--- a/initial/pom.xml
+++ b/initial/pom.xml
@@ -24,6 +24,14 @@
 			<artifactId>spring-boot-starter-integration</artifactId>
 		</dependency>
 		<dependency>
+			<groupId>org.springframework.integration</groupId>
+			<artifactId>spring-integration-feed</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.integration</groupId>
+			<artifactId>spring-integration-file</artifactId>
+		</dependency>
+		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-test</artifactId>
 			<scope>test</scope>


### PR DESCRIPTION
Hi,

The [Spring Integration getting started](https://spring.io/guides/gs/integration/) suggests to:
* Download and unzip the source repository for this guide, or clone it using Git: git clone https://github.com/spring-guides/gs-integration.git
* cd into `gs-integration/initial`
* Jump ahead to [Define an Integration Flow](https://spring.io/guides/gs/integration/#initial).

This path skip the **Add to the Build Files** section, which ask to add spring-integration-feed & spring-integration-file dependencies.

Therefore, someone following the guide might encounter an error. Based on #14, it looks it is expected to have already these dependencies declared in the build files.